### PR TITLE
curl package: add new stable version 7.75.0

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -14,7 +14,8 @@ class Curl(AutotoolsPackage):
     homepage = "https://curl.se/"
     # URL must remain http:// so Spack can bootstrap curl
     url      = "http://curl.haxx.se/download/curl-7.74.0.tar.bz2"
-
+    
+    version('7.75.0', sha256='50552d4501c178e4cc68baaecc487f466a3d6d19bbf4e50a01869effb316d026')
     version('7.74.0', sha256='0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5')
     version('7.73.0', sha256='cf34fe0b07b800f1c01a499a6e8b2af548f6d0e044dca4a29d88a4bee146d131')
     version('7.72.0', sha256='ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef')


### PR DESCRIPTION
The most recent stable version of cURL is 7.75.0, released on 3rd of February 2021, which introduces some interesting features like using Rust Hyper Library to implement a new HTTP backend.